### PR TITLE
Hotfix/download method

### DIFF
--- a/main.R
+++ b/main.R
@@ -54,7 +54,7 @@ histYES <- T
 ## Input file with list of earthquakes to download -------------------
 # File must be a single column txt file with DBMI IDs one per row
 # see file eventListTemplate.csv for an example
-eqEventsFile <- "~/Dropbox/Projects/Rosetta/dbmiEventsList2.csv"
+eqEventsFile <- "./eventListTemplate.csv"
 
 ## output directory declaration --------------------------------------
 #outdir <- "/home/roberto/Dropbox/Rosetta/outputDirectory"

--- a/main.R
+++ b/main.R
@@ -97,7 +97,8 @@ scaricali <- function(inputID) {download.file(
         "?eventid=",
         inputID,
         "&includemdps=true&format=textmacro", sep = ""),
-  destfile = paste(downloadPath, "/", inputID, "_DBMI.csv", sep = ""))
+  destfile = paste(downloadPath, "/", inputID, "_DBMI.csv", sep = ""),
+  'libcurl')
   Sys.sleep(0.5)
 }
 


### PR DESCRIPTION
executing main.R in docker debian:stable script fails due a missing download method. Set libcurl, should be available on all platforms (see docs: https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/download.file )

follow the returned error:
```
root@3aadf4dd0fff:/opt/rosetta# ./main.R 

Attaching package: 'dplyr'

The following objects are masked from 'package:stats':

    filter, lag

The following objects are masked from 'package:base':

    intersect, setdiff, setequal, union

Loading required package: grid
Error in download.file(paste(asmiServUrl, "?eventid=", inputID, "&includemdps=true&format=textmacro",  : 
  'url' must be a length-one character vector
Calls: sapply -> lapply -> FUN -> download.file
Execution halted
```